### PR TITLE
ci: add ruff lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Lint
+        run: |
+          ruff check src tests
+          ruff format --check src tests
+
       - name: Run tests
         run: pytest tests/ -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,20 @@ Please install it before your first commit.
 
 Tests are fully offline - no real API calls, no real tokens. Fixtures use fictional data and round numbers; never paste real health measurements into tests.
 
+### Run lint checks
+
+```bash
+.venv/bin/python -m ruff check src tests
+.venv/bin/python -m ruff format --check src tests
+```
+
 ## Making changes
 
 - **Open an issue first** for non-trivial changes (new tools, schema migrations, new measurement types, breaking changes). Small fixes (typos, bug fixes, docs) can go straight to a PR.
 - Keep PRs small and focused.
 - Add or update tests for any behaviour change.
 - This server is intentionally read-only - PRs that add write tools will not be accepted.
+- Run `ruff check src tests` and `ruff format --check src tests` before opening a PR.
 - Run `pytest tests/ -v` before opening a PR.
 
 ## Pull requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.3.5",
+    "ruff>=0.6",
 ]
 
 [project.scripts]
@@ -34,3 +35,13 @@ Issues = "https://github.com/partymola/withings-mcp/issues"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/main.py" = ["E402"]

--- a/src/main.py
+++ b/src/main.py
@@ -17,18 +17,21 @@ logging.basicConfig(
 
 # Import MCP instance and register all tools
 from withings_mcp.mcp_instance import mcp  # noqa: E402
-from withings_mcp.tools import sync_tools  # noqa: E402, F401
-from withings_mcp.tools import body_tools  # noqa: E402, F401
-from withings_mcp.tools import sleep_tools  # noqa: E402, F401
-from withings_mcp.tools import activity_tools  # noqa: E402, F401
-from withings_mcp.tools import heart_tools  # noqa: E402, F401
-from withings_mcp.tools import device_tools  # noqa: E402, F401
-from withings_mcp.tools import analysis_tools  # noqa: E402, F401
+from withings_mcp.tools import (
+    activity_tools,  # noqa: E402, F401
+    analysis_tools,  # noqa: E402, F401
+    body_tools,  # noqa: E402, F401
+    device_tools,  # noqa: E402, F401
+    heart_tools,  # noqa: E402, F401
+    sleep_tools,  # noqa: E402, F401
+    sync_tools,  # noqa: E402, F401
+)
 
 
 def main():
     if len(sys.argv) > 1 and sys.argv[1] == "auth":
         from withings_mcp.auth import setup_auth
+
         setup_auth()
     else:
         mcp.run(transport="stdio")

--- a/src/withings_mcp/api.py
+++ b/src/withings_mcp/api.py
@@ -42,17 +42,22 @@ def post(url: str, params: dict, retries: int = 2) -> dict:
     for attempt in range(retries):
         token = refresh_token()
         data = urlencode(params).encode()
-        req = urllib.request.Request(url, data=data, method="POST", headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/x-www-form-urlencoded",
-            "User-Agent": "withings-mcp/0.1",
-        })
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": "withings-mcp/0.1",
+            },
+        )
 
         try:
             with urllib.request.urlopen(req, timeout=15) as resp:
                 body = json.loads(resp.read().decode())
         except urllib.error.URLError as e:
-            raise WithingsAPIError(f"Network error. Check your connection.") from e
+            raise WithingsAPIError("Network error. Check your connection.") from e
 
         status = body.get("status")
 
@@ -63,6 +68,7 @@ def post(url: str, params: dict, retries: int = 2) -> dict:
             # Token expired - force refresh and retry
             logger.info("Token expired (401), refreshing")
             from . import auth
+
             auth._cached_tokens = None
             continue
 

--- a/src/withings_mcp/auth.py
+++ b/src/withings_mcp/auth.py
@@ -14,13 +14,18 @@ import time
 import urllib.error
 import urllib.request
 import webbrowser
-from http.server import HTTPServer, BaseHTTPRequestHandler
-from urllib.parse import urlparse, parse_qs, urlencode
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from .config import (
-    CONFIG_DIR, WITHINGS_CLIENT_PATH, WITHINGS_TOKENS_PATH,
-    WITHINGS_AUTH_URL, WITHINGS_TOKEN_URL, WITHINGS_SCOPES,
-    WITHINGS_CALLBACK_PORT, WITHINGS_REDIRECT_URI,
+    CONFIG_DIR,
+    WITHINGS_AUTH_URL,
+    WITHINGS_CALLBACK_PORT,
+    WITHINGS_CLIENT_PATH,
+    WITHINGS_REDIRECT_URI,
+    WITHINGS_SCOPES,
+    WITHINGS_TOKEN_URL,
+    WITHINGS_TOKENS_PATH,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,14 +47,16 @@ def _load_json(path):
 
 def _exchange_code(code, client_id, client_secret):
     """Exchange auth code for tokens. Must complete within 30 seconds."""
-    data = urlencode({
-        "action": "requesttoken",
-        "grant_type": "authorization_code",
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "code": code,
-        "redirect_uri": WITHINGS_REDIRECT_URI,
-    }).encode()
+    data = urlencode(
+        {
+            "action": "requesttoken",
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+            "redirect_uri": WITHINGS_REDIRECT_URI,
+        }
+    ).encode()
 
     req = urllib.request.Request(WITHINGS_TOKEN_URL, data=data, method="POST")
     req.add_header("Content-Type", "application/x-www-form-urlencoded")
@@ -86,13 +93,15 @@ def refresh_token() -> str:
         logger.error("Token expired and no refresh token. Run: withings-mcp auth")
         raise RuntimeError("Token expired and no refresh token. Run: withings-mcp auth")
 
-    data = urlencode({
-        "action": "requesttoken",
-        "grant_type": "refresh_token",
-        "client_id": _cached_creds["client_id"],
-        "client_secret": _cached_creds["client_secret"],
-        "refresh_token": _cached_tokens["refresh_token"],
-    }).encode()
+    data = urlencode(
+        {
+            "action": "requesttoken",
+            "grant_type": "refresh_token",
+            "client_id": _cached_creds["client_id"],
+            "client_secret": _cached_creds["client_secret"],
+            "refresh_token": _cached_tokens["refresh_token"],
+        }
+    ).encode()
 
     req = urllib.request.Request(WITHINGS_TOKEN_URL, data=data, method="POST")
     req.add_header("Content-Type", "application/x-www-form-urlencoded")
@@ -101,7 +110,7 @@ def refresh_token() -> str:
             body = json.loads(resp.read().decode())
     except urllib.error.URLError as e:
         logger.error("Token refresh failed: %s", e)
-        raise RuntimeError(f"Token refresh failed. Run: withings-mcp auth") from e
+        raise RuntimeError("Token refresh failed. Run: withings-mcp auth") from e
 
     if body.get("status") != 0:
         logger.error("Token refresh returned status %s", body.get("status"))
@@ -167,9 +176,7 @@ def setup_auth():
                 return
 
             # Exchange immediately (30-second window)
-            tokens, err = _exchange_code(
-                code, creds["client_id"], creds["client_secret"]
-            )
+            tokens, err = _exchange_code(code, creds["client_id"], creds["client_secret"])
             if err:
                 self._respond(500, f"Token exchange failed: {err}")
                 auth_result["error"] = err
@@ -181,22 +188,26 @@ def setup_auth():
             self.send_response(status_code)
             self.send_header("Content-Type", "text/html")
             self.end_headers()
-            self.wfile.write(
-                f"<html><body><h2>{message}</h2></body></html>".encode()
-            )
+            self.wfile.write(f"<html><body><h2>{message}</h2></body></html>".encode())
 
         def log_message(self, format, *args):
             pass
 
-    auth_url = WITHINGS_AUTH_URL + "?" + urlencode({
-        "response_type": "code",
-        "client_id": creds["client_id"],
-        "scope": WITHINGS_SCOPES,
-        "redirect_uri": WITHINGS_REDIRECT_URI,
-        "state": state,
-    })
+    auth_url = (
+        WITHINGS_AUTH_URL
+        + "?"
+        + urlencode(
+            {
+                "response_type": "code",
+                "client_id": creds["client_id"],
+                "scope": WITHINGS_SCOPES,
+                "redirect_uri": WITHINGS_REDIRECT_URI,
+                "state": state,
+            }
+        )
+    )
 
-    print(f"\nOpening browser for Withings auth...")
+    print("\nOpening browser for Withings auth...")
     print(f"If it doesn't open, visit:\n{auth_url}\n")
     webbrowser.open(auth_url)
 
@@ -225,4 +236,5 @@ def setup_auth():
     _save_json(WITHINGS_TOKENS_PATH, token_store)
     print(f"Tokens saved. User ID: {tokens.get('userid')}")
     print("\nSetup complete. Register with Claude Code:")
-    print(f"  claude mcp add -s user withings -- {sys.executable.replace('/bin/python', '/bin/withings-mcp')}")
+    command = sys.executable.replace("/bin/python", "/bin/withings-mcp")
+    print(f"  claude mcp add -s user withings -- {command}")

--- a/src/withings_mcp/db.py
+++ b/src/withings_mcp/db.py
@@ -179,8 +179,9 @@ def save_workout(conn: sqlite3.Connection, row: dict):
     )
 
 
-def log_sync(conn: sqlite3.Connection, data_type: str, status: str,
-             records_added: int = 0, notes: str = ""):
+def log_sync(
+    conn: sqlite3.Connection, data_type: str, status: str, records_added: int = 0, notes: str = ""
+):
     """Record a sync event."""
     conn.execute(
         """INSERT INTO sync_log (synced_at, data_type, status, records_added, notes)
@@ -234,8 +235,9 @@ def query_activities(conn: sqlite3.Connection, start_date: str, end_date: str) -
     return [dict(r) for r in rows]
 
 
-def query_workouts(conn: sqlite3.Connection, start_date: str, end_date: str,
-                   category: str | None = None) -> list[dict]:
+def query_workouts(
+    conn: sqlite3.Connection, start_date: str, end_date: str, category: str | None = None
+) -> list[dict]:
     """Query workouts within a date range, optionally filtered by category."""
     if category:
         rows = conn.execute(

--- a/src/withings_mcp/helpers.py
+++ b/src/withings_mcp/helpers.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 # --- Response formatting ---
 
+
 def format_response(result: Any) -> str:
     """JSON-serialize a result for MCP transport."""
     if isinstance(result, (dict, list)):
@@ -25,6 +26,7 @@ def format_response(result: Any) -> str:
 
 
 # --- Withings value decoding ---
+
 
 def parse_value(measure: dict) -> float:
     """Decode a Withings measurement value.
@@ -87,12 +89,11 @@ def _parse_single_date(date_str: str | None, default: date, is_end: bool) -> dat
     if re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
         return date.fromisoformat(date_str)
 
-    raise ValueError(
-        f"Invalid date '{date_str}'. Use YYYY-MM-DD, YYYY-MM, or Nd (e.g. '30d')."
-    )
+    raise ValueError(f"Invalid date '{date_str}'. Use YYYY-MM-DD, YYYY-MM, or Nd (e.g. '30d').")
 
 
 # --- Formatting helpers ---
+
 
 def format_duration(seconds: int | None) -> str:
     """Convert seconds to human-readable duration."""
@@ -116,15 +117,20 @@ def format_distance(meters: float | None) -> str:
 
 # --- Auth decorator ---
 
+
 def require_auth(func):
     """Decorator that checks credentials exist before calling a tool."""
+
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
         if not WITHINGS_CLIENT_PATH.exists() or not WITHINGS_TOKENS_PATH.exists():
-            return json.dumps({
-                "error": "Withings not configured. Run: withings-mcp auth",
-            })
+            return json.dumps(
+                {
+                    "error": "Withings not configured. Run: withings-mcp auth",
+                }
+            )
         return await func(*args, **kwargs)
+
     return wrapper
 
 
@@ -151,18 +157,53 @@ MEASURE_TYPES = {
 }
 
 WORKOUT_CATEGORIES = {
-    1: "walk", 2: "run", 3: "hiking", 4: "skating", 5: "bmx",
-    6: "cycling", 7: "swimming", 8: "surfing", 9: "kitesurfing",
-    10: "windsurfing", 11: "bodyboard", 12: "tennis", 13: "table_tennis",
-    14: "squash", 15: "badminton", 16: "weightlifting", 17: "calisthenics",
-    18: "elliptical", 19: "pilates", 20: "basketball", 21: "soccer",
-    22: "football", 23: "rugby", 24: "volleyball", 25: "waterpolo",
-    26: "horse_riding", 27: "golf", 28: "yoga", 29: "dancing",
-    30: "boxing", 31: "fencing", 32: "wrestling", 33: "martial_arts",
-    34: "skiing", 35: "snowboarding", 36: "other",
-    187: "rowing", 188: "zumba", 191: "baseball", 192: "handball",
-    193: "hockey", 194: "ice_hockey", 195: "climbing", 196: "ice_skating",
-    272: "multi_sport", 306: "indoor_walk", 307: "indoor_running",
+    1: "walk",
+    2: "run",
+    3: "hiking",
+    4: "skating",
+    5: "bmx",
+    6: "cycling",
+    7: "swimming",
+    8: "surfing",
+    9: "kitesurfing",
+    10: "windsurfing",
+    11: "bodyboard",
+    12: "tennis",
+    13: "table_tennis",
+    14: "squash",
+    15: "badminton",
+    16: "weightlifting",
+    17: "calisthenics",
+    18: "elliptical",
+    19: "pilates",
+    20: "basketball",
+    21: "soccer",
+    22: "football",
+    23: "rugby",
+    24: "volleyball",
+    25: "waterpolo",
+    26: "horse_riding",
+    27: "golf",
+    28: "yoga",
+    29: "dancing",
+    30: "boxing",
+    31: "fencing",
+    32: "wrestling",
+    33: "martial_arts",
+    34: "skiing",
+    35: "snowboarding",
+    36: "other",
+    187: "rowing",
+    188: "zumba",
+    191: "baseball",
+    192: "handball",
+    193: "hockey",
+    194: "ice_hockey",
+    195: "climbing",
+    196: "ice_skating",
+    272: "multi_sport",
+    306: "indoor_walk",
+    307: "indoor_running",
     308: "indoor_cycling",
 }
 

--- a/src/withings_mcp/tools/activity_tools.py
+++ b/src/withings_mcp/tools/activity_tools.py
@@ -1,17 +1,21 @@
 """Activity and workout query tools."""
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import anyio
 
-from ..mcp_instance import mcp
-from ..helpers import (
-    format_response, require_auth, parse_date,
-    format_duration, format_distance, resolve_workout_category,
-)
 from .. import api, db
 from ..config import WITHINGS_MEASURE_V2_URL
+from ..helpers import (
+    format_distance,
+    format_duration,
+    format_response,
+    parse_date,
+    require_auth,
+    resolve_workout_category,
+)
+from ..mcp_instance import mcp
 from .sync_tools import auto_sync_if_stale
 
 logger = logging.getLogger(__name__)
@@ -30,32 +34,37 @@ def _fetch_activity_live(start_date, end_date):
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_MEASURE_V2_URL, {
-            "action": "getactivity",
-            "startdateymd": start_date.isoformat(),
-            "enddateymd": end_date.isoformat(),
-            "data_fields": _ACTIVITY_FIELDS,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_MEASURE_V2_URL,
+            {
+                "action": "getactivity",
+                "startdateymd": start_date.isoformat(),
+                "enddateymd": end_date.isoformat(),
+                "data_fields": _ACTIVITY_FIELDS,
+                "offset": offset,
+            },
+        )
 
         activities = body.get("activities", [])
         if isinstance(activities, dict):
             activities = [activities]
 
         for entry in activities:
-            results.append({
-                "date": entry.get("date", ""),
-                "steps": entry.get("steps"),
-                "distance": format_distance(entry.get("distance")),
-                "active_calories": entry.get("calories"),
-                "total_calories": entry.get("totalcalories"),
-                "light_activity": format_duration(entry.get("soft")),
-                "moderate_activity": format_duration(entry.get("moderate")),
-                "intense_activity": format_duration(entry.get("intense")),
-                "hr_average": entry.get("hr_average"),
-                "hr_min": entry.get("hr_min"),
-                "hr_max": entry.get("hr_max"),
-            })
+            results.append(
+                {
+                    "date": entry.get("date", ""),
+                    "steps": entry.get("steps"),
+                    "distance": format_distance(entry.get("distance")),
+                    "active_calories": entry.get("calories"),
+                    "total_calories": entry.get("totalcalories"),
+                    "light_activity": format_duration(entry.get("soft")),
+                    "moderate_activity": format_duration(entry.get("moderate")),
+                    "intense_activity": format_duration(entry.get("intense")),
+                    "hr_average": entry.get("hr_average"),
+                    "hr_min": entry.get("hr_min"),
+                    "hr_max": entry.get("hr_max"),
+                }
+            )
 
         if body.get("more", False):
             offset = body.get("offset", 0)
@@ -71,13 +80,16 @@ def _fetch_workouts_live(start_date, end_date, category=None):
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_MEASURE_V2_URL, {
-            "action": "getworkouts",
-            "startdateymd": start_date.isoformat(),
-            "enddateymd": end_date.isoformat(),
-            "data_fields": _WORKOUT_FIELDS,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_MEASURE_V2_URL,
+            {
+                "action": "getworkouts",
+                "startdateymd": start_date.isoformat(),
+                "enddateymd": end_date.isoformat(),
+                "data_fields": _WORKOUT_FIELDS,
+                "offset": offset,
+            },
+        )
 
         for entry in body.get("series", []):
             data = entry.get("data", {})
@@ -89,17 +101,19 @@ def _fetch_workouts_live(start_date, end_date, category=None):
 
             start_ts = entry.get("startdate", 0)
             end_ts = entry.get("enddate", 0)
-            results.append({
-                "date": datetime.fromtimestamp(start_ts, tz=timezone.utc).strftime("%Y-%m-%d"),
-                "type": cat_name,
-                "duration": format_duration(end_ts - start_ts if end_ts and start_ts else 0),
-                "calories": data.get("calories"),
-                "distance": format_distance(data.get("distance")),
-                "steps": data.get("steps"),
-                "hr_average": data.get("hr_average"),
-                "hr_min": data.get("hr_min"),
-                "hr_max": data.get("hr_max"),
-            })
+            results.append(
+                {
+                    "date": datetime.fromtimestamp(start_ts, tz=timezone.utc).strftime("%Y-%m-%d"),
+                    "type": cat_name,
+                    "duration": format_duration(end_ts - start_ts if end_ts and start_ts else 0),
+                    "calories": data.get("calories"),
+                    "distance": format_distance(data.get("distance")),
+                    "steps": data.get("steps"),
+                    "hr_average": data.get("hr_average"),
+                    "hr_min": data.get("hr_min"),
+                    "hr_max": data.get("hr_max"),
+                }
+            )
 
         if body.get("more", False):
             offset = body.get("offset", 0)
@@ -137,6 +151,7 @@ async def withings_get_activity(
         entries = await anyio.to_thread.run_sync(lambda: _fetch_activity_live(start, end))
     else:
         await anyio.to_thread.run_sync(lambda: auto_sync_if_stale("activity"))
+
         def _query():
             conn = db.get_db()
             rows = db.query_activities(conn, start.isoformat(), end.isoformat())
@@ -147,13 +162,16 @@ async def withings_get_activity(
                 r["moderate_activity"] = format_duration(r.get("moderate_sec"))
                 r["intense_activity"] = format_duration(r.get("intense_sec"))
             return rows
+
         entries = await anyio.to_thread.run_sync(_query)
 
     if not entries:
-        return format_response({
-            "message": "No activity data found for this period.",
-            "hint": "Try live=True to fetch directly from the API.",
-        })
+        return format_response(
+            {
+                "message": "No activity data found for this period.",
+                "hint": "Try live=True to fetch directly from the API.",
+            }
+        )
 
     return format_response({"days": entries, "count": len(entries)})
 
@@ -186,11 +204,10 @@ async def withings_get_workouts(
     start, end = parse_date(start_date, end_date, default_days=90)
 
     if live:
-        entries = await anyio.to_thread.run_sync(
-            lambda: _fetch_workouts_live(start, end, category)
-        )
+        entries = await anyio.to_thread.run_sync(lambda: _fetch_workouts_live(start, end, category))
     else:
         await anyio.to_thread.run_sync(lambda: auto_sync_if_stale("workouts"))
+
         def _query():
             conn = db.get_db()
             rows = db.query_workouts(conn, start.isoformat(), end.isoformat(), category)
@@ -200,12 +217,15 @@ async def withings_get_workouts(
                 r["duration"] = format_duration(r.get("duration_sec"))
                 r["distance"] = format_distance(r.get("distance_m"))
             return rows
+
         entries = await anyio.to_thread.run_sync(_query)
 
     if not entries:
-        return format_response({
-            "message": "No workouts found for this period.",
-            "hint": "Try live=True to fetch directly from the API.",
-        })
+        return format_response(
+            {
+                "message": "No workouts found for this period.",
+                "hint": "Try live=True to fetch directly from the API.",
+            }
+        )
 
     return format_response({"workouts": entries, "count": len(entries)})

--- a/src/withings_mcp/tools/analysis_tools.py
+++ b/src/withings_mcp/tools/analysis_tools.py
@@ -7,9 +7,9 @@ from datetime import date, timedelta
 
 import anyio
 
-from ..mcp_instance import mcp
-from ..helpers import format_response, require_auth, parse_date, format_duration
 from .. import db
+from ..helpers import format_duration, format_response, parse_date, require_auth
+from ..mcp_instance import mcp
 from .sync_tools import auto_sync_if_stale
 
 logger = logging.getLogger(__name__)
@@ -39,10 +39,21 @@ def _trend_body(conn, start_date: str, end_date: str, period: str) -> dict:
     """Compute body composition trends."""
     rows = db.query_body(conn, start_date, end_date)
     if not rows:
-        return {"message": "No body data in cache for this period. Try live=True on the get_* tools to fetch directly from the API."}
+        return {
+            "message": (
+                "No body data in cache for this period. Try live=True on the "
+                "get_* tools to fetch directly from the API."
+            )
+        }
 
-    fields = ["weight_kg", "fat_pct", "fat_mass_kg", "muscle_mass_kg",
-              "bone_mass_kg", "hydration_kg"]
+    fields = [
+        "weight_kg",
+        "fat_pct",
+        "fat_mass_kg",
+        "muscle_mass_kg",
+        "bone_mass_kg",
+        "hydration_kg",
+    ]
     buckets = defaultdict(lambda: defaultdict(list))
 
     for r in rows:
@@ -66,10 +77,22 @@ def _trend_sleep(conn, start_date: str, end_date: str, period: str) -> dict:
     """Compute sleep trends."""
     rows = db.query_sleep(conn, start_date, end_date)
     if not rows:
-        return {"message": "No sleep data in cache for this period. Try live=True on the get_* tools to fetch directly from the API."}
+        return {
+            "message": (
+                "No sleep data in cache for this period. Try live=True on the "
+                "get_* tools to fetch directly from the API."
+            )
+        }
 
-    fields = ["total_sleep_sec", "deep_sleep_sec", "light_sleep_sec",
-              "rem_sleep_sec", "sleep_score", "hr_average", "rr_average"]
+    fields = [
+        "total_sleep_sec",
+        "deep_sleep_sec",
+        "light_sleep_sec",
+        "rem_sleep_sec",
+        "sleep_score",
+        "hr_average",
+        "rr_average",
+    ]
     buckets = defaultdict(lambda: defaultdict(list))
 
     for r in rows:
@@ -101,7 +124,12 @@ def _trend_activity(conn, start_date: str, end_date: str, period: str) -> dict:
     """Compute activity trends."""
     rows = db.query_activities(conn, start_date, end_date)
     if not rows:
-        return {"message": "No activity data in cache for this period. Try live=True on the get_* tools to fetch directly from the API."}
+        return {
+            "message": (
+                "No activity data in cache for this period. Try live=True on the "
+                "get_* tools to fetch directly from the API."
+            )
+        }
 
     fields = ["steps", "distance_m", "active_calories", "total_calories"]
     buckets = defaultdict(lambda: defaultdict(list))
@@ -120,7 +148,9 @@ def _trend_activity(conn, start_date: str, end_date: str, period: str) -> dict:
             "period": key,
             "days": len(b.get("steps", [])),
             "avg_steps": _avg(b.get("steps", [])),
-            "total_distance_km": round(sum(b.get("distance_m", [])) / 1000, 1) if b.get("distance_m") else None,
+            "total_distance_km": round(sum(b.get("distance_m", [])) / 1000, 1)
+            if b.get("distance_m")
+            else None,
             "avg_active_calories": _avg(b.get("active_calories", [])),
         }
         periods.append(entry)
@@ -133,7 +163,11 @@ def _compare_periods(conn, data_type: str, compare_str: str) -> dict:
     # Parse the comparison string
     parts = re.split(r"\s+vs\s+", compare_str.strip(), maxsplit=1)
     if len(parts) != 2:
-        return {"error": "Invalid compare format. Use: 'last_30d vs previous_30d' or '2026-03 vs 2026-02'"}
+        return {
+            "error": (
+                "Invalid compare format. Use: 'last_30d vs previous_30d' or '2026-03 vs 2026-02'"
+            )
+        }
 
     today = date.today()
     ranges = []
@@ -169,12 +203,20 @@ def _compare_periods(conn, data_type: str, compare_str: str) -> dict:
                 end = date(year, end_month + 1, 1) - timedelta(days=1)
             ranges.append((start, end))
             continue
-        return {"error": f"Cannot parse period '{part}'. Use: last_30d, previous_30d, 2026-03, or 2026-Q1"}
+        return {
+            "error": (
+                f"Cannot parse period '{part}'. Use: last_30d, previous_30d, 2026-03, or 2026-Q1"
+            )
+        }
 
     if len(ranges) != 2:
         return {"error": "Need exactly two periods to compare."}
 
-    query_fn = {"body": db.query_body, "sleep": db.query_sleep, "activity": db.query_activities}.get(data_type)
+    query_fn = {
+        "body": db.query_body,
+        "sleep": db.query_sleep,
+        "activity": db.query_activities,
+    }.get(data_type)
     if not query_fn:
         return {"error": f"Cannot compare data_type '{data_type}'. Use: body, sleep, or activity."}
 
@@ -239,6 +281,7 @@ async def withings_trends(
     For activity: steps, distance, calorie trends.
     Not for raw data -- use withings_get_body/sleep/activity instead.
     """
+
     def _analyse():
         auto_sync_if_stale(data_type)
         conn = db.get_db()
@@ -256,7 +299,9 @@ async def withings_trends(
             elif data_type == "activity":
                 result = _trend_activity(conn, s, e, period)
             else:
-                result = {"error": f"Unknown data_type '{data_type}'. Use: body, sleep, or activity."}
+                result = {
+                    "error": f"Unknown data_type '{data_type}'. Use: body, sleep, or activity."
+                }
 
         conn.close()
         return result

--- a/src/withings_mcp/tools/body_tools.py
+++ b/src/withings_mcp/tools/body_tools.py
@@ -5,13 +5,17 @@ from datetime import datetime, timedelta, timezone
 
 import anyio
 
-from ..mcp_instance import mcp
-from ..helpers import (
-    format_response, require_auth, parse_date, parse_value,
-    resolve_measure_type, MEASURE_TYPES,
-)
 from .. import api, db
 from ..config import WITHINGS_MEASURE_URL
+from ..helpers import (
+    MEASURE_TYPES,
+    format_response,
+    parse_date,
+    parse_value,
+    require_auth,
+    resolve_measure_type,
+)
+from ..mcp_instance import mcp
 from .sync_tools import auto_sync_if_stale
 
 logger = logging.getLogger(__name__)
@@ -21,23 +25,29 @@ _BODY_MEASTYPES = ",".join(str(k) for k in MEASURE_TYPES.keys())
 
 def _fetch_live(start_date, end_date):
     """Fetch body measurements directly from the API."""
-    start_ts = int(datetime.combine(start_date, datetime.min.time(),
-                                     tzinfo=timezone.utc).timestamp())
-    end_ts = int(datetime.combine(end_date + timedelta(days=1),
-                                   datetime.min.time(),
-                                   tzinfo=timezone.utc).timestamp())
+    start_ts = int(
+        datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+    )
+    end_ts = int(
+        datetime.combine(
+            end_date + timedelta(days=1), datetime.min.time(), tzinfo=timezone.utc
+        ).timestamp()
+    )
     results = []
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_MEASURE_URL, {
-            "action": "getmeas",
-            "meastypes": _BODY_MEASTYPES,
-            "category": 1,
-            "startdate": start_ts,
-            "enddate": end_ts,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_MEASURE_URL,
+            {
+                "action": "getmeas",
+                "meastypes": _BODY_MEASTYPES,
+                "category": 1,
+                "startdate": start_ts,
+                "enddate": end_ts,
+                "offset": offset,
+            },
+        )
 
         for grp in body.get("measuregrps", []):
             ts = grp.get("date", 0)
@@ -91,11 +101,13 @@ async def withings_get_body(
         entries = await anyio.to_thread.run_sync(lambda: _fetch_live(start, end))
     else:
         await anyio.to_thread.run_sync(lambda: auto_sync_if_stale("body"))
+
         def _query():
             conn = db.get_db()
             rows = db.query_body(conn, start.isoformat(), end.isoformat())
             conn.close()
             return rows
+
         entries = await anyio.to_thread.run_sync(_query)
 
     # Filter metrics if requested
@@ -105,9 +117,11 @@ async def withings_get_body(
         entries = [{k: v for k, v in e.items() if k in keep} for e in entries]
 
     if not entries:
-        return format_response({
-            "message": "No body measurements found for this period.",
-            "hint": "Try live=True to fetch directly from the API.",
-        })
+        return format_response(
+            {
+                "message": "No body measurements found for this period.",
+                "hint": "Try live=True to fetch directly from the API.",
+            }
+        )
 
     return format_response({"measurements": entries, "count": len(entries)})

--- a/src/withings_mcp/tools/device_tools.py
+++ b/src/withings_mcp/tools/device_tools.py
@@ -5,10 +5,10 @@ from datetime import datetime, timezone
 
 import anyio
 
-from ..mcp_instance import mcp
-from ..helpers import format_response, require_auth
 from .. import api
 from ..config import WITHINGS_USER_V2_URL
+from ..helpers import format_response, require_auth
+from ..mcp_instance import mcp
 
 logger = logging.getLogger(__name__)
 
@@ -21,17 +21,19 @@ def _fetch_devices():
     for d in body.get("devices", []):
         last_session = d.get("last_session_date")
         if last_session:
-            last_session = datetime.fromtimestamp(
-                last_session, tz=timezone.utc
-            ).strftime("%Y-%m-%d %H:%M")
+            last_session = datetime.fromtimestamp(last_session, tz=timezone.utc).strftime(
+                "%Y-%m-%d %H:%M"
+            )
 
-        devices.append({
-            "type": d.get("type", ""),
-            "model": d.get("model", ""),
-            "battery": d.get("battery", ""),
-            "last_session": last_session,
-            "timezone": d.get("timezone", ""),
-        })
+        devices.append(
+            {
+                "type": d.get("type", ""),
+                "model": d.get("model", ""),
+                "battery": d.get("battery", ""),
+                "last_session": last_session,
+                "timezone": d.get("timezone", ""),
+            }
+        )
 
     return devices
 
@@ -49,9 +51,11 @@ async def withings_get_devices() -> str:
     devices = await anyio.to_thread.run_sync(_fetch_devices)
 
     if not devices:
-        return format_response({
-            "message": "No connected devices found.",
-            "hint": "Ensure devices are registered in the Withings app.",
-        })
+        return format_response(
+            {
+                "message": "No connected devices found.",
+                "hint": "Ensure devices are registered in the Withings app.",
+            }
+        )
 
     return format_response({"devices": devices, "count": len(devices)})

--- a/src/withings_mcp/tools/heart_tools.py
+++ b/src/withings_mcp/tools/heart_tools.py
@@ -5,10 +5,10 @@ from datetime import datetime, timedelta, timezone
 
 import anyio
 
-from ..mcp_instance import mcp
-from ..helpers import format_response, require_auth, parse_date
 from .. import api
 from ..config import WITHINGS_HEART_V2_URL
+from ..helpers import format_response, parse_date, require_auth
+from ..mcp_instance import mcp
 
 logger = logging.getLogger(__name__)
 
@@ -17,32 +17,40 @@ _AFIB_STATUS = {0: "negative", 1: "positive", 2: "inconclusive"}
 
 def _fetch_heart(start_date, end_date):
     """Fetch ECG recordings from the API."""
-    start_ts = int(datetime.combine(start_date, datetime.min.time(),
-                                     tzinfo=timezone.utc).timestamp())
-    end_ts = int(datetime.combine(end_date + timedelta(days=1),
-                                   datetime.min.time(),
-                                   tzinfo=timezone.utc).timestamp())
+    start_ts = int(
+        datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+    )
+    end_ts = int(
+        datetime.combine(
+            end_date + timedelta(days=1), datetime.min.time(), tzinfo=timezone.utc
+        ).timestamp()
+    )
     results = []
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_HEART_V2_URL, {
-            "action": "list",
-            "startdate": start_ts,
-            "enddate": end_ts,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_HEART_V2_URL,
+            {
+                "action": "list",
+                "startdate": start_ts,
+                "enddate": end_ts,
+                "offset": offset,
+            },
+        )
 
         for entry in body.get("series", []):
             ecg = entry.get("ecg", {})
-            results.append({
-                "date": datetime.fromtimestamp(
-                    entry.get("timestamp", 0), tz=timezone.utc
-                ).strftime("%Y-%m-%d %H:%M"),
-                "heart_rate": entry.get("heart_rate"),
-                "afib": _AFIB_STATUS.get(ecg.get("afib"), "unknown"),
-                "signal_id": entry.get("signalid"),
-            })
+            results.append(
+                {
+                    "date": datetime.fromtimestamp(
+                        entry.get("timestamp", 0), tz=timezone.utc
+                    ).strftime("%Y-%m-%d %H:%M"),
+                    "heart_rate": entry.get("heart_rate"),
+                    "afib": _AFIB_STATUS.get(ecg.get("afib"), "unknown"),
+                    "signal_id": entry.get("signalid"),
+                }
+            )
 
         if body.get("more", False):
             offset = body.get("offset", 0)
@@ -78,9 +86,11 @@ async def withings_get_heart(
     recordings = await anyio.to_thread.run_sync(lambda: _fetch_heart(start, end))
 
     if not recordings:
-        return format_response({
-            "message": "No ECG recordings found for this period.",
-            "hint": "Requires a Withings device with ECG capability (ScanWatch, BPM Core).",
-        })
+        return format_response(
+            {
+                "message": "No ECG recordings found for this period.",
+                "hint": "Requires a Withings device with ECG capability (ScanWatch, BPM Core).",
+            }
+        )
 
     return format_response({"recordings": recordings, "count": len(recordings)})

--- a/src/withings_mcp/tools/sleep_tools.py
+++ b/src/withings_mcp/tools/sleep_tools.py
@@ -5,13 +5,16 @@ from datetime import datetime, timedelta, timezone
 
 import anyio
 
-from ..mcp_instance import mcp
-from ..helpers import (
-    format_response, require_auth, parse_date,
-    format_duration, resolve_sleep_state,
-)
 from .. import api, db
 from ..config import WITHINGS_SLEEP_V2_URL
+from ..helpers import (
+    format_duration,
+    format_response,
+    parse_date,
+    require_auth,
+    resolve_sleep_state,
+)
+from ..mcp_instance import mcp
 from .sync_tools import auto_sync_if_stale
 
 logger = logging.getLogger(__name__)
@@ -29,31 +32,36 @@ def _fetch_summary_live(start_date, end_date):
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_SLEEP_V2_URL, {
-            "action": "getsummary",
-            "startdateymd": start_date.isoformat(),
-            "enddateymd": end_date.isoformat(),
-            "data_fields": _SUMMARY_FIELDS,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_SLEEP_V2_URL,
+            {
+                "action": "getsummary",
+                "startdateymd": start_date.isoformat(),
+                "enddateymd": end_date.isoformat(),
+                "data_fields": _SUMMARY_FIELDS,
+                "offset": offset,
+            },
+        )
 
         for entry in body.get("series", []):
             data = entry.get("data", {})
-            results.append({
-                "date": entry.get("date", ""),
-                "total_sleep": format_duration(data.get("total_sleep_time")),
-                "deep_sleep": format_duration(data.get("deepsleepduration")),
-                "light_sleep": format_duration(data.get("lightsleepduration")),
-                "rem_sleep": format_duration(data.get("remsleepduration")),
-                "awake": format_duration(data.get("wakeupduration")),
-                "wakeup_count": data.get("wakeupcount"),
-                "hr_average": data.get("hr_average"),
-                "hr_min": data.get("hr_min"),
-                "hr_max": data.get("hr_max"),
-                "rr_average": data.get("rr_average"),
-                "sleep_score": data.get("sleep_score"),
-                "snoring": format_duration(data.get("snoring")),
-            })
+            results.append(
+                {
+                    "date": entry.get("date", ""),
+                    "total_sleep": format_duration(data.get("total_sleep_time")),
+                    "deep_sleep": format_duration(data.get("deepsleepduration")),
+                    "light_sleep": format_duration(data.get("lightsleepduration")),
+                    "rem_sleep": format_duration(data.get("remsleepduration")),
+                    "awake": format_duration(data.get("wakeupduration")),
+                    "wakeup_count": data.get("wakeupcount"),
+                    "hr_average": data.get("hr_average"),
+                    "hr_min": data.get("hr_min"),
+                    "hr_max": data.get("hr_max"),
+                    "rr_average": data.get("rr_average"),
+                    "sleep_score": data.get("sleep_score"),
+                    "snoring": format_duration(data.get("snoring")),
+                }
+            )
 
         if body.get("more", False):
             offset = body.get("offset", 0)
@@ -65,28 +73,36 @@ def _fetch_summary_live(start_date, end_date):
 
 def _fetch_detail_live(start_date, end_date):
     """Fetch detailed sleep phases from the API. Max 7 days."""
-    start_ts = int(datetime.combine(start_date, datetime.min.time(),
-                                     tzinfo=timezone.utc).timestamp())
-    end_ts = int(datetime.combine(end_date + timedelta(days=1),
-                                   datetime.min.time(),
-                                   tzinfo=timezone.utc).timestamp())
+    start_ts = int(
+        datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+    )
+    end_ts = int(
+        datetime.combine(
+            end_date + timedelta(days=1), datetime.min.time(), tzinfo=timezone.utc
+        ).timestamp()
+    )
 
-    body = api.post(WITHINGS_SLEEP_V2_URL, {
-        "action": "get",
-        "startdate": start_ts,
-        "enddate": end_ts,
-        "data_fields": "hr,rr,snoring",
-    })
+    body = api.post(
+        WITHINGS_SLEEP_V2_URL,
+        {
+            "action": "get",
+            "startdate": start_ts,
+            "enddate": end_ts,
+            "data_fields": "hr,rr,snoring",
+        },
+    )
 
     phases = []
     for entry in body.get("series", []):
-        phases.append({
-            "start": datetime.fromtimestamp(entry["startdate"], tz=timezone.utc).isoformat(),
-            "end": datetime.fromtimestamp(entry["enddate"], tz=timezone.utc).isoformat(),
-            "state": resolve_sleep_state(entry.get("state", 5)),
-            "hr": entry.get("hr"),
-            "rr": entry.get("rr"),
-        })
+        phases.append(
+            {
+                "start": datetime.fromtimestamp(entry["startdate"], tz=timezone.utc).isoformat(),
+                "end": datetime.fromtimestamp(entry["enddate"], tz=timezone.utc).isoformat(),
+                "state": resolve_sleep_state(entry.get("state", 5)),
+                "hr": entry.get("hr"),
+                "rr": entry.get("rr"),
+            }
+        )
 
     return phases
 
@@ -130,15 +146,18 @@ async def withings_get_sleep(
 
         phases = await anyio.to_thread.run_sync(lambda: _fetch_detail_live(start, end))
         if not phases:
-            return format_response({
-                "message": "No detailed sleep data found for this period.",
-            })
+            return format_response(
+                {
+                    "message": "No detailed sleep data found for this period.",
+                }
+            )
         return format_response({"phases": phases, "count": len(phases)})
 
     if live:
         entries = await anyio.to_thread.run_sync(lambda: _fetch_summary_live(start, end))
     else:
         await anyio.to_thread.run_sync(lambda: auto_sync_if_stale("sleep"))
+
         def _query():
             conn = db.get_db()
             rows = db.query_sleep(conn, start.isoformat(), end.isoformat())
@@ -152,12 +171,15 @@ async def withings_get_sleep(
                 r["awake"] = format_duration(r.get("awake_sec"))
                 r["snoring"] = format_duration(r.get("snoring_sec"))
             return rows
+
         entries = await anyio.to_thread.run_sync(_query)
 
     if not entries:
-        return format_response({
-            "message": "No sleep data found for this period.",
-            "hint": "Try live=True to fetch directly from the API.",
-        })
+        return format_response(
+            {
+                "message": "No sleep data found for this period.",
+                "hint": "Try live=True to fetch directly from the API.",
+            }
+        )
 
     return format_response({"nights": entries, "count": len(entries)})

--- a/src/withings_mcp/tools/sync_tools.py
+++ b/src/withings_mcp/tools/sync_tools.py
@@ -1,22 +1,25 @@
 """Sync tool: fetch data from Withings API and store in local SQLite cache."""
 
 import logging
-import time
-from datetime import datetime, date, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import anyio
 
-from ..mcp_instance import mcp
-from ..helpers import (
-    format_response, require_auth, parse_value,
-    resolve_measure_type, resolve_workout_category,
-    MEASURE_TYPES,
-)
 from .. import api, db
 from ..config import (
-    WITHINGS_MEASURE_URL, WITHINGS_MEASURE_V2_URL,
+    WITHINGS_MEASURE_URL,
+    WITHINGS_MEASURE_V2_URL,
     WITHINGS_SLEEP_V2_URL,
 )
+from ..helpers import (
+    MEASURE_TYPES,
+    format_response,
+    parse_value,
+    require_auth,
+    resolve_measure_type,
+    resolve_workout_category,
+)
+from ..mcp_instance import mcp
 
 logger = logging.getLogger(__name__)
 
@@ -51,11 +54,14 @@ def run_sync(types: list[str], days: int = 30) -> dict:
             end_date = today
             start_ymd = start_date.isoformat()
             end_ymd = end_date.isoformat()
-            start_ts = int(datetime.combine(start_date, datetime.min.time(),
-                                             tzinfo=timezone.utc).timestamp())
-            end_ts = int(datetime.combine(end_date + timedelta(days=1),
-                                           datetime.min.time(),
-                                           tzinfo=timezone.utc).timestamp())
+            start_ts = int(
+                datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            )
+            end_ts = int(
+                datetime.combine(
+                    end_date + timedelta(days=1), datetime.min.time(), tzinfo=timezone.utc
+                ).timestamp()
+            )
 
             if dtype == "body":
                 count = _sync_body(conn, start_ts, end_ts)
@@ -70,7 +76,11 @@ def run_sync(types: list[str], days: int = 30) -> dict:
                 continue
 
             db.log_sync(conn, dtype, "ok", count)
-            results[dtype] = {"status": "ok", "records": count, "range": f"{start_ymd} to {end_ymd}"}
+            results[dtype] = {
+                "status": "ok",
+                "records": count,
+                "range": f"{start_ymd} to {end_ymd}",
+            }
 
         except api.WithingsRateLimitError:
             db.log_sync(conn, dtype, "partial", notes="rate limited")
@@ -103,6 +113,7 @@ def auto_sync_if_stale(data_type: str) -> None:
     except Exception:
         pass
 
+
 # Sleep summary fields to request
 _SLEEP_DATA_FIELDS = (
     "total_sleep_time,deepsleepduration,lightsleepduration,remsleepduration,"
@@ -117,9 +128,7 @@ _ACTIVITY_DATA_FIELDS = (
 )
 
 # Workout fields to request
-_WORKOUT_DATA_FIELDS = (
-    "calories,distance,steps,hr_average,hr_min,hr_max"
-)
+_WORKOUT_DATA_FIELDS = "calories,distance,steps,hr_average,hr_min,hr_max"
 
 
 def _sync_body(conn, start_ts: int, end_ts: int) -> int:
@@ -128,14 +137,17 @@ def _sync_body(conn, start_ts: int, end_ts: int) -> int:
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_MEASURE_URL, {
-            "action": "getmeas",
-            "meastypes": _BODY_MEASTYPES,
-            "category": 1,
-            "startdate": start_ts,
-            "enddate": end_ts,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_MEASURE_URL,
+            {
+                "action": "getmeas",
+                "meastypes": _BODY_MEASTYPES,
+                "category": 1,
+                "startdate": start_ts,
+                "enddate": end_ts,
+                "offset": offset,
+            },
+        )
 
         for grp in body.get("measuregrps", []):
             ts = grp.get("date", 0)
@@ -186,20 +198,27 @@ def _sync_sleep(conn, start_ymd: str, end_ymd: str) -> int:
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_SLEEP_V2_URL, {
-            "action": "getsummary",
-            "startdateymd": start_ymd,
-            "enddateymd": end_ymd,
-            "data_fields": _SLEEP_DATA_FIELDS,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_SLEEP_V2_URL,
+            {
+                "action": "getsummary",
+                "startdateymd": start_ymd,
+                "enddateymd": end_ymd,
+                "data_fields": _SLEEP_DATA_FIELDS,
+                "offset": offset,
+            },
+        )
 
         for entry in body.get("series", []):
             data = entry.get("data", {})
             start_ts = entry.get("startdate")
             end_ts = entry.get("enddate")
-            startdate = datetime.fromtimestamp(start_ts, tz=timezone.utc).isoformat() if start_ts else None
-            enddate = datetime.fromtimestamp(end_ts, tz=timezone.utc).isoformat() if end_ts else None
+            startdate = (
+                datetime.fromtimestamp(start_ts, tz=timezone.utc).isoformat() if start_ts else None
+            )
+            enddate = (
+                datetime.fromtimestamp(end_ts, tz=timezone.utc).isoformat() if end_ts else None
+            )
 
             row = {
                 "date": entry.get("date", ""),
@@ -240,13 +259,16 @@ def _sync_activity(conn, start_ymd: str, end_ymd: str) -> int:
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_MEASURE_V2_URL, {
-            "action": "getactivity",
-            "startdateymd": start_ymd,
-            "enddateymd": end_ymd,
-            "data_fields": _ACTIVITY_DATA_FIELDS,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_MEASURE_V2_URL,
+            {
+                "action": "getactivity",
+                "startdateymd": start_ymd,
+                "enddateymd": end_ymd,
+                "data_fields": _ACTIVITY_DATA_FIELDS,
+                "offset": offset,
+            },
+        )
 
         activities = body.get("activities", [])
         # Single-day quirk: might return an object instead of array
@@ -289,13 +311,16 @@ def _sync_workouts(conn, start_ymd: str, end_ymd: str) -> int:
     offset = 0
 
     while True:
-        body = api.post(WITHINGS_MEASURE_V2_URL, {
-            "action": "getworkouts",
-            "startdateymd": start_ymd,
-            "enddateymd": end_ymd,
-            "data_fields": _WORKOUT_DATA_FIELDS,
-            "offset": offset,
-        })
+        body = api.post(
+            WITHINGS_MEASURE_V2_URL,
+            {
+                "action": "getworkouts",
+                "startdateymd": start_ymd,
+                "enddateymd": end_ymd,
+                "data_fields": _WORKOUT_DATA_FIELDS,
+                "offset": offset,
+            },
+        )
 
         for entry in body.get("series", []):
             data = entry.get("data", {})

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,13 +4,11 @@ ALL test data in this project MUST come from this module.
 Values are obviously fictional round numbers - never use real health data.
 """
 
-import math
-
 
 def _encode_value(value, decimals=1):
     """Encode a float as Withings value + unit (value * 10^unit)."""
     unit = -decimals
-    encoded = round(value * (10 ** decimals))
+    encoded = round(value * (10**decimals))
     return {"value": encoded, "type": 0, "unit": unit}
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,17 +2,15 @@
 
 import json
 import unittest
-from unittest.mock import patch, MagicMock
-from io import BytesIO
+from unittest.mock import MagicMock, patch
 
+from tests.fixtures import fake_api_response
 from withings_mcp.api import (
     WithingsAPIError,
     WithingsAuthError,
     WithingsRateLimitError,
     post,
 )
-
-from tests.fixtures import fake_api_response
 
 
 def _mock_urlopen(response_dict):
@@ -29,18 +27,14 @@ class TestApiPost(unittest.TestCase):
     @patch("withings_mcp.api.urllib.request.urlopen")
     def test_success_returns_body(self, mock_urlopen, mock_refresh):
         body_data = {"measuregrps": []}
-        mock_urlopen.return_value = _mock_urlopen(
-            fake_api_response(status=0, body=body_data)
-        )
+        mock_urlopen.return_value = _mock_urlopen(fake_api_response(status=0, body=body_data))
         result = post("https://example.com", {"action": "getmeas"})
         self.assertEqual(result, body_data)
 
     @patch("withings_mcp.api.refresh_token", return_value="fake_token")
     @patch("withings_mcp.api.urllib.request.urlopen")
     def test_401_raises_auth_error(self, mock_urlopen, mock_refresh):
-        mock_urlopen.return_value = _mock_urlopen(
-            fake_api_response(status=401)
-        )
+        mock_urlopen.return_value = _mock_urlopen(fake_api_response(status=401))
         with self.assertRaises(WithingsAuthError) as ctx:
             post("https://example.com", {"action": "getmeas"})
         self.assertIn("withings-mcp auth", str(ctx.exception))
@@ -48,9 +42,7 @@ class TestApiPost(unittest.TestCase):
     @patch("withings_mcp.api.refresh_token", return_value="fake_token")
     @patch("withings_mcp.api.urllib.request.urlopen")
     def test_601_raises_rate_limit(self, mock_urlopen, mock_refresh):
-        mock_urlopen.return_value = _mock_urlopen(
-            fake_api_response(status=601)
-        )
+        mock_urlopen.return_value = _mock_urlopen(fake_api_response(status=601))
         with self.assertRaises(WithingsRateLimitError) as ctx:
             post("https://example.com", {"action": "getmeas"}, retries=1)
         self.assertIn("60 seconds", str(ctx.exception))
@@ -58,18 +50,14 @@ class TestApiPost(unittest.TestCase):
     @patch("withings_mcp.api.refresh_token", return_value="fake_token")
     @patch("withings_mcp.api.urllib.request.urlopen")
     def test_602_raises_rate_limit(self, mock_urlopen, mock_refresh):
-        mock_urlopen.return_value = _mock_urlopen(
-            fake_api_response(status=602)
-        )
+        mock_urlopen.return_value = _mock_urlopen(fake_api_response(status=602))
         with self.assertRaises(WithingsRateLimitError):
             post("https://example.com", {"action": "getmeas"}, retries=1)
 
     @patch("withings_mcp.api.refresh_token", return_value="fake_token")
     @patch("withings_mcp.api.urllib.request.urlopen")
     def test_unknown_status_raises_api_error(self, mock_urlopen, mock_refresh):
-        mock_urlopen.return_value = _mock_urlopen(
-            fake_api_response(status=2555)
-        )
+        mock_urlopen.return_value = _mock_urlopen(fake_api_response(status=2555))
         with self.assertRaises(WithingsAPIError) as ctx:
             post("https://example.com", {"action": "getmeas"}, retries=1)
         self.assertIn("2555", str(ctx.exception))
@@ -78,6 +66,7 @@ class TestApiPost(unittest.TestCase):
     @patch("withings_mcp.api.urllib.request.urlopen")
     def test_network_error_raises_api_error(self, mock_urlopen, mock_refresh):
         import urllib.error
+
         mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
         with self.assertRaises(WithingsAPIError):
             post("https://example.com", {"action": "getmeas"})
@@ -106,9 +95,7 @@ class TestApiPost(unittest.TestCase):
     @patch("withings_mcp.api.refresh_token", return_value="fake_token")
     @patch("withings_mcp.api.urllib.request.urlopen")
     def test_success_returns_empty_body(self, mock_urlopen, mock_refresh):
-        mock_urlopen.return_value = _mock_urlopen(
-            {"status": 0}
-        )
+        mock_urlopen.return_value = _mock_urlopen({"status": 0})
         result = post("https://example.com", {"action": "getdevice"})
         self.assertEqual(result, {})
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,21 +3,20 @@
 All tests use in-memory SQLite - no on-disk files created.
 """
 
-import sqlite3
 import unittest
 
 from withings_mcp.db import (
     get_db,
-    save_body_measurement,
-    save_sleep_summary,
-    save_activity,
-    save_workout,
-    log_sync,
     get_last_sync,
+    log_sync,
+    query_activities,
     query_body,
     query_sleep,
-    query_activities,
     query_workouts,
+    save_activity,
+    save_body_measurement,
+    save_sleep_summary,
+    save_workout,
 )
 
 
@@ -54,12 +53,22 @@ class TestSchema(unittest.TestCase):
 class TestBodyMeasurements(unittest.TestCase):
     def _make_row(self, grpid=1001, date="2026-01-15", weight=70.0, fat_pct=20.0):
         return {
-            "date": date, "measured_at": "2026-01-15T08:00:00+00:00",
-            "grpid": grpid, "weight_kg": weight, "fat_pct": fat_pct,
-            "fat_mass_kg": 14.0, "lean_mass_kg": 56.0, "muscle_mass_kg": 30.0,
-            "hydration_kg": 38.0, "bone_mass_kg": 3.0, "heart_rate": None,
-            "systolic_bp": None, "diastolic_bp": None, "spo2_pct": None,
-            "temperature_c": None, "visceral_fat_index": None,
+            "date": date,
+            "measured_at": "2026-01-15T08:00:00+00:00",
+            "grpid": grpid,
+            "weight_kg": weight,
+            "fat_pct": fat_pct,
+            "fat_mass_kg": 14.0,
+            "lean_mass_kg": 56.0,
+            "muscle_mass_kg": 30.0,
+            "hydration_kg": 38.0,
+            "bone_mass_kg": 3.0,
+            "heart_rate": None,
+            "systolic_bp": None,
+            "diastolic_bp": None,
+            "spo2_pct": None,
+            "temperature_c": None,
+            "visceral_fat_index": None,
             "basal_metabolic_rate": None,
         }
 
@@ -93,15 +102,25 @@ class TestBodyMeasurements(unittest.TestCase):
 class TestSleepSummaries(unittest.TestCase):
     def _make_row(self, date="2026-01-15", device="32"):
         return {
-            "date": date, "startdate": "2026-01-14T23:00:00+00:00",
+            "date": date,
+            "startdate": "2026-01-14T23:00:00+00:00",
             "enddate": "2026-01-15T07:00:00+00:00",
-            "total_sleep_sec": 28800, "deep_sleep_sec": 3600,
-            "light_sleep_sec": 14400, "rem_sleep_sec": 7200,
-            "awake_sec": 3600, "wakeup_count": 2,
-            "hr_average": 58, "hr_min": 48, "hr_max": 72,
-            "rr_average": 15, "rr_min": 12, "rr_max": 19,
-            "sleep_score": 78, "snoring_sec": 600,
-            "apnea_hypopnea_index": None, "device_model": device,
+            "total_sleep_sec": 28800,
+            "deep_sleep_sec": 3600,
+            "light_sleep_sec": 14400,
+            "rem_sleep_sec": 7200,
+            "awake_sec": 3600,
+            "wakeup_count": 2,
+            "hr_average": 58,
+            "hr_min": 48,
+            "hr_max": 72,
+            "rr_average": 15,
+            "rr_min": 12,
+            "rr_max": 19,
+            "sleep_score": 78,
+            "snoring_sec": 600,
+            "apnea_hypopnea_index": None,
+            "device_model": device,
         }
 
     def test_insert_and_retrieve(self):
@@ -132,12 +151,21 @@ class TestSleepSummaries(unittest.TestCase):
 class TestActivities(unittest.TestCase):
     def _make_row(self, date="2026-01-15"):
         return {
-            "date": date, "steps": 8000, "distance_m": 6000,
-            "active_calories": 250, "total_calories": 1850,
-            "soft_sec": 5400, "moderate_sec": 1800, "intense_sec": 600,
-            "hr_average": 72, "hr_min": 55, "hr_max": 145,
-            "hr_zone_0_sec": 3600, "hr_zone_1_sec": 1800,
-            "hr_zone_2_sec": 600, "hr_zone_3_sec": 120,
+            "date": date,
+            "steps": 8000,
+            "distance_m": 6000,
+            "active_calories": 250,
+            "total_calories": 1850,
+            "soft_sec": 5400,
+            "moderate_sec": 1800,
+            "intense_sec": 600,
+            "hr_average": 72,
+            "hr_min": 55,
+            "hr_max": 145,
+            "hr_zone_0_sec": 3600,
+            "hr_zone_1_sec": 1800,
+            "hr_zone_2_sec": 600,
+            "hr_zone_3_sec": 120,
         }
 
     def test_insert_and_retrieve(self):
@@ -160,12 +188,18 @@ class TestActivities(unittest.TestCase):
 class TestWorkouts(unittest.TestCase):
     def _make_row(self, startdate="2026-01-15T10:00:00+00:00", category=6):
         return {
-            "date": "2026-01-15", "startdate": startdate,
+            "date": "2026-01-15",
+            "startdate": startdate,
             "enddate": "2026-01-15T11:00:00+00:00",
-            "category": category, "category_name": "cycling",
-            "duration_sec": 3600, "calories": 350,
-            "distance_m": 15000, "steps": 0,
-            "hr_average": 135, "hr_min": 95, "hr_max": 170,
+            "category": category,
+            "category_name": "cycling",
+            "duration_sec": 3600,
+            "calories": 350,
+            "distance_m": 15000,
+            "steps": 0,
+            "hr_average": 135,
+            "hr_min": 95,
+            "hr_max": 170,
         }
 
     def test_insert_and_retrieve(self):
@@ -187,14 +221,10 @@ class TestWorkouts(unittest.TestCase):
     def test_category_filter(self):
         conn = _get_test_db()
         save_workout(conn, self._make_row(category=6))
-        save_workout(conn, self._make_row(
-            startdate="2026-01-16T10:00:00+00:00", category=2
-        ))
+        save_workout(conn, self._make_row(startdate="2026-01-16T10:00:00+00:00", category=2))
         conn.commit()
         # Fix: second workout needs different category_name
-        conn.execute(
-            "UPDATE workouts SET category_name='run' WHERE category=2"
-        )
+        conn.execute("UPDATE workouts SET category_name='run' WHERE category=2")
         conn.commit()
         rows = query_workouts(conn, "2026-01-01", "2026-01-31", category="cycling")
         self.assertEqual(len(rows), 1)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,21 +23,15 @@ class TestParseValue(unittest.TestCase):
 
     def test_negative_exponent(self):
         # 72500 * 10^-3 = 72.5
-        self.assertAlmostEqual(
-            parse_value({"value": 72500, "unit": -3}), 72.5, places=3
-        )
+        self.assertAlmostEqual(parse_value({"value": 72500, "unit": -3}), 72.5, places=3)
 
     def test_two_decimal_exponent(self):
         # 2015 * 10^-2 = 20.15
-        self.assertAlmostEqual(
-            parse_value({"value": 2015, "unit": -2}), 20.15, places=3
-        )
+        self.assertAlmostEqual(parse_value({"value": 2015, "unit": -2}), 20.15, places=3)
 
     def test_large_negative_exponent(self):
         # 700000 * 10^-4 = 70.0
-        self.assertAlmostEqual(
-            parse_value({"value": 700000, "unit": -4}), 70.0, places=3
-        )
+        self.assertAlmostEqual(parse_value({"value": 700000, "unit": -4}), 70.0, places=3)
 
     def test_positive_unit(self):
         # 5 * 10^1 = 50

--- a/tests/test_trends.py
+++ b/tests/test_trends.py
@@ -1,13 +1,19 @@
 """Tests for trend analysis: aggregation, comparison, sparse data."""
 
-import sqlite3
 import unittest
 
 from withings_mcp.db import (
-    get_db, save_body_measurement, save_sleep_summary, save_activity,
+    get_db,
+    save_activity,
+    save_body_measurement,
+    save_sleep_summary,
 )
 from withings_mcp.tools.analysis_tools import (
-    _trend_body, _trend_sleep, _trend_activity, _compare_periods, _get_period_key,
+    _compare_periods,
+    _get_period_key,
+    _trend_activity,
+    _trend_body,
+    _trend_sleep,
 )
 
 
@@ -17,38 +23,67 @@ def _get_test_db():
 
 def _body_row(date, grpid, weight=70.0, fat_pct=20.0, muscle=30.0):
     return {
-        "date": date, "measured_at": f"{date}T08:00:00+00:00",
-        "grpid": grpid, "weight_kg": weight, "fat_pct": fat_pct,
-        "fat_mass_kg": weight * fat_pct / 100, "lean_mass_kg": None,
-        "muscle_mass_kg": muscle, "hydration_kg": None, "bone_mass_kg": None,
-        "heart_rate": None, "systolic_bp": None, "diastolic_bp": None,
-        "spo2_pct": None, "temperature_c": None, "visceral_fat_index": None,
+        "date": date,
+        "measured_at": f"{date}T08:00:00+00:00",
+        "grpid": grpid,
+        "weight_kg": weight,
+        "fat_pct": fat_pct,
+        "fat_mass_kg": weight * fat_pct / 100,
+        "lean_mass_kg": None,
+        "muscle_mass_kg": muscle,
+        "hydration_kg": None,
+        "bone_mass_kg": None,
+        "heart_rate": None,
+        "systolic_bp": None,
+        "diastolic_bp": None,
+        "spo2_pct": None,
+        "temperature_c": None,
+        "visceral_fat_index": None,
         "basal_metabolic_rate": None,
     }
 
 
 def _sleep_row(date, device="32", total=28800, score=78):
     return {
-        "date": date, "startdate": f"{date}T23:00:00+00:00",
+        "date": date,
+        "startdate": f"{date}T23:00:00+00:00",
         "enddate": f"{date}T07:00:00+00:00",
-        "total_sleep_sec": total, "deep_sleep_sec": 3600,
-        "light_sleep_sec": 14400, "rem_sleep_sec": 7200,
-        "awake_sec": 3600, "wakeup_count": 2,
-        "hr_average": 58, "hr_min": 48, "hr_max": 72,
-        "rr_average": 15, "rr_min": 12, "rr_max": 19,
-        "sleep_score": score, "snoring_sec": 600,
-        "apnea_hypopnea_index": None, "device_model": device,
+        "total_sleep_sec": total,
+        "deep_sleep_sec": 3600,
+        "light_sleep_sec": 14400,
+        "rem_sleep_sec": 7200,
+        "awake_sec": 3600,
+        "wakeup_count": 2,
+        "hr_average": 58,
+        "hr_min": 48,
+        "hr_max": 72,
+        "rr_average": 15,
+        "rr_min": 12,
+        "rr_max": 19,
+        "sleep_score": score,
+        "snoring_sec": 600,
+        "apnea_hypopnea_index": None,
+        "device_model": device,
     }
 
 
 def _activity_row(date, steps=8000, distance=6000):
     return {
-        "date": date, "steps": steps, "distance_m": distance,
-        "active_calories": 250, "total_calories": 1850,
-        "soft_sec": 5400, "moderate_sec": 1800, "intense_sec": 600,
-        "hr_average": 72, "hr_min": 55, "hr_max": 145,
-        "hr_zone_0_sec": 3600, "hr_zone_1_sec": 1800,
-        "hr_zone_2_sec": 600, "hr_zone_3_sec": 120,
+        "date": date,
+        "steps": steps,
+        "distance_m": distance,
+        "active_calories": 250,
+        "total_calories": 1850,
+        "soft_sec": 5400,
+        "moderate_sec": 1800,
+        "intense_sec": 600,
+        "hr_average": 72,
+        "hr_min": 55,
+        "hr_max": 145,
+        "hr_zone_0_sec": 3600,
+        "hr_zone_1_sec": 1800,
+        "hr_zone_2_sec": 600,
+        "hr_zone_3_sec": 120,
     }
 
 
@@ -70,11 +105,15 @@ class TestBodyTrends(unittest.TestCase):
     def test_monthly_averages(self):
         conn = _get_test_db()
         # Jan: 70, 71 -> avg 70.5. Feb: 69, 70 -> avg 69.5. Mar: 68.
-        for i, (d, w) in enumerate([
-            ("2026-01-05", 70.0), ("2026-01-20", 71.0),
-            ("2026-02-05", 69.0), ("2026-02-20", 70.0),
-            ("2026-03-10", 68.0),
-        ]):
+        for i, (d, w) in enumerate(
+            [
+                ("2026-01-05", 70.0),
+                ("2026-01-20", 71.0),
+                ("2026-02-05", 69.0),
+                ("2026-02-20", 70.0),
+                ("2026-03-10", 68.0),
+            ]
+        ):
             save_body_measurement(conn, _body_row(d, grpid=2000 + i, weight=w))
         conn.commit()
 


### PR DESCRIPTION
Fixes #5

## Summary

Adds Ruff linting and formatting checks to CI so lint errors and formatting drift fail before pytest runs.

## Changes

- Adds `ruff>=0.6` to the dev extra.
- Adds minimal Ruff config with `E`, `F`, and `I` rules, Python 3.13 target, and a 100-column line length.
- Adds a CI lint step before the test step.
- Documents local Ruff commands in CONTRIBUTING.md.
- Applies Ruff formatting/lint cleanup in a separate commit for easier review.

## Testing

- [x] `uv run --extra dev ruff check src tests`
- [x] `uv run --extra dev ruff format --check src tests`
- [x] `uv run --extra dev pytest tests/ -q` -> 74 passed

## Notes

No runtime dependencies were added. The formatting cleanup is isolated in its own commit.