### PR TITLE
feat: add CLI version flag

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,15 @@
 """Withings MCP server entry point.
 
 Usage:
-    withings-mcp          Start the MCP server (stdio transport)
-    withings-mcp auth     Interactive OAuth setup
+    withings-mcp              Start the MCP server (stdio transport)
+    withings-mcp --version    Print the installed package version
+    withings-mcp auth         Interactive OAuth setup
 """
 
+import argparse
 import logging
 import sys
+from importlib.metadata import version
 
 # Configure logging to stderr (stdout is reserved for JSON-RPC on stdio)
 logging.basicConfig(
@@ -28,8 +31,32 @@ from withings_mcp.tools import (
 )
 
 
+def _version_text():
+    return f"withings-mcp {version('withings-mcp')}"
+
+
+def _add_version_argument(parser):
+    parser.add_argument("--version", action="version", version=_version_text())
+
+
 def main():
-    if len(sys.argv) > 1 and sys.argv[1] == "auth":
+    if len(sys.argv) == 1:
+        mcp.run(transport="stdio")
+        return
+
+    parser = argparse.ArgumentParser(
+        prog="withings-mcp",
+        description="Withings MCP server - serves Withings health data via MCP.",
+    )
+    _add_version_argument(parser)
+    subparsers = parser.add_subparsers(dest="cmd", metavar="COMMAND")
+
+    auth_parser = subparsers.add_parser("auth", help="Interactive OAuth setup")
+    _add_version_argument(auth_parser)
+
+    args = parser.parse_args()
+
+    if args.cmd == "auth":
         from withings_mcp.auth import setup_auth
 
         setup_auth()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+"""Tests for the withings-mcp command-line entry point."""
+
+from importlib.metadata import version
+from unittest.mock import Mock, patch
+
+import pytest
+
+import main
+
+
+def test_version_flag_prints_package_version(capsys):
+    with patch("sys.argv", ["withings-mcp", "--version"]):
+        with pytest.raises(SystemExit) as exc_info:
+            main.main()
+
+    assert exc_info.value.code == 0
+    assert capsys.readouterr().out.strip() == f"withings-mcp {version('withings-mcp')}"
+
+
+def test_version_flag_takes_precedence_over_subcommand(capsys):
+    with patch("sys.argv", ["withings-mcp", "auth", "--version"]):
+        with pytest.raises(SystemExit) as exc_info:
+            main.main()
+
+    assert exc_info.value.code == 0
+    assert capsys.readouterr().out.strip() == f"withings-mcp {version('withings-mcp')}"
+
+
+def test_version_flag_does_not_mask_invalid_subcommand_args(capsys):
+    with patch("sys.argv", ["withings-mcp", "bogus", "--version"]):
+        with pytest.raises(SystemExit) as exc_info:
+            main.main()
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code != 0
+    assert f"withings-mcp {version('withings-mcp')}" not in captured.out
+
+
+def test_no_args_starts_stdio_server():
+    run_mock = Mock()
+
+    with patch("sys.argv", ["withings-mcp"]), patch.object(main.mcp, "run", run_mock):
+        main.main()
+
+    run_mock.assert_called_once_with(transport="stdio")
+
+
+def test_auth_subcommand_runs_setup_auth():
+    with (
+        patch("sys.argv", ["withings-mcp", "auth"]),
+        patch("withings_mcp.auth.setup_auth") as setup_auth,
+    ):
+        main.main()
+
+    setup_auth.assert_called_once_with()


### PR DESCRIPTION
## Summary

Adds an argparse-based CLI path with a standard `--version` flag that reads the installed `withings-mcp` package version. The existing no-argument path still starts the MCP server over stdio, and `withings-mcp auth` still runs the OAuth setup flow.

The flag is available at the root and auth subcommand levels, so both `withings-mcp --version` and `withings-mcp auth --version` print `withings-mcp 0.1.0`. Malformed commands still return argparse errors instead of letting `--version` mask invalid input.

Closes #1

## Verification

- `git diff --check`
- `./scripts/check-no-data.sh`
- `.venv/bin/python -m pytest tests/ -q`
- `.venv/bin/ruff check src/main.py tests/test_cli.py`
- `.venv/bin/ruff format --check src/main.py tests/test_cli.py`
- `.venv/bin/withings-mcp --version`
- `.venv/bin/withings-mcp auth --version`
- `.venv/bin/withings-mcp bogus --version` exits nonzero
